### PR TITLE
Remove util.promisfy and fs usage for browser use

### DIFF
--- a/ActionLibrary.js
+++ b/ActionLibrary.js
@@ -1,9 +1,3 @@
-const util = require('util');
-const fs = require('fs');
-const path = require('path');
-
-const readdir = util.promisify(fs.readdir);
-
 class ActionLibrary {
   constructor() {
     this.actions = {};
@@ -14,18 +8,6 @@ class ActionLibrary {
       throw `Second action added with ID ${id}`;
     }
     this.actions[id] = actionClass;
-  }
-
-  async addActionsFromDir(dirPath) {
-    const files = await readdir(dirPath);
-    const self = this;
-    files.filter(f => f.endsWith('.js'))
-         .forEach(f => {
-            const p = path.join(dirPath, f);
-            const id = f.slice(0,-3);
-            const c = require(p);
-            self.addAction(id, c);
-         });
   }
 
   getAction(id) {

--- a/README.md
+++ b/README.md
@@ -105,10 +105,6 @@ you pass to the `orchestrator` does this, providing `Action` classes as required
 
 * `addAction(id, actionClass)` - Adds an `Action`, associating it with the given
   identifier to allow it to be referenced from a `Rule`.
-* `async addActionsFromDir(dirPath)` - Adds all `.js` files from the directory
-  at `dirPath`, loading the exported class as an `Action` with an identifier
-  based on the file name. A file `myAction.js` would have the identifier
-  `myAction`.
 * `getAction(id)` - a function that accepts an action identifier
   and returns the class implementing that action. If an `Action` is requested
   that cannot be loaded this MUST either throw an error (which will halt

--- a/test/ActionLibrary.test.js
+++ b/test/ActionLibrary.test.js
@@ -1,6 +1,4 @@
 const ActionLibrary = require('../ActionLibrary');
-const fs = require('fs');
-const path = require('path');
 
 describe('ActionLibrary', () => {
 
@@ -30,16 +28,6 @@ describe('ActionLibrary', () => {
   test("fetching an ID that doesn't exist throws an error", () => {
     const lib = new ActionLibrary();
     expect(() => lib.getAction("Foo")).toThrow();
-  });
-
-  test("can load all actions from a directory", async () => {
-    expect.assertions(3);
-    const dirPath = fs.realpathSync(path.join(__dirname,'fixtureActions'));
-    const lib = new ActionLibrary();
-    await lib.addActionsFromDir(dirPath);
-    expect(lib.getAction("AppendA")).toBeInstanceOf(Function);
-    expect(lib.getAction("AppendB")).toBeInstanceOf(Function);
-    expect(lib.getAction("AppendC")).toBeInstanceOf(Function);
   });
 
 

--- a/test/orchestrator.test.js
+++ b/test/orchestrator.test.js
@@ -1,17 +1,17 @@
-const fs = require('fs');
-const path = require('path');
-
 const orchestrator = require("../orchestrator");
 const ActionLibrary = require("../ActionLibrary");
-
-const FIXTURE_ACTION_PATH = fs.realpathSync(path.join(__dirname,'fixtureActions'));
+const AppendA = require("./fixtureActions/AppendA");
+const AppendB = require("./fixtureActions/AppendB");
+const AppendC = require("./fixtureActions/AppendC");
 
 describe("orchestrator", () => {
 
   var actions;
   beforeEach(async () => {
     actions = new ActionLibrary();
-    await actions.addActionsFromDir(FIXTURE_ACTION_PATH);
+    actions.addAction("AppendA", AppendA);
+    actions.addAction("AppendB", AppendB);
+    actions.addAction("AppendC", AppendC);
   });
 
   describe("Rule selection and processing", () => {


### PR DESCRIPTION
To help support ImperfectHuman/rule-based-system-example it's necessary to resolve a dependency on `util.promisify`, or to polyfill it. Given the utility nature of the involved code it seems better to focus on the core functionality, and to allow other helper libraries to be created for such purposes, if needed.